### PR TITLE
Use cortex-m-rt attributes instead of macros for IRQs in board crates

### DIFF
--- a/board/arduino-zero/src/lib.rs
+++ b/board/arduino-zero/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
-#![feature(use_extern_macros)]
 
 extern crate panic_abort;
 extern crate cortex_m_rt;
+use cortex_m_rt::exception;
 pub extern crate samd21 as mcu;
 
 
@@ -28,6 +28,17 @@ impl bobbin_sys::board::Board for ArduinoZero {
     fn id(&self) -> &'static str { "arduino-zero" }    
 }
 
-cortex_m_rt::default_handler!(bobbin_sys::irq_dispatch::IrqDispatcher::<Mcu>::handle_exception);
-cortex_m_rt::exception!(SYS_TICK, bobbin_sys::tick::Tick::tick);
-cortex_m_rt::exception!(PENDSV, bobbin_sys::pend::Pend::pend);
+#[exception]
+fn DefaultHandler(_irqn: i16) {
+    bobbin_sys::irq_dispatch::IrqDispatcher::<Mcu>::handle_exception();
+}
+
+#[exception]
+fn SysTick() {
+    bobbin_sys::tick::Tick::tick();
+}
+
+#[exception]
+fn PendSV() {
+    bobbin_sys::pend::Pend::pend();
+}

--- a/board/discovery-stm32f3/src/lib.rs
+++ b/board/discovery-stm32f3/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
-#![feature(use_extern_macros)]
 
 extern crate panic_abort;
 extern crate cortex_m_rt;
+use cortex_m_rt::exception;
 pub extern crate stm32f3x as mcu;
 
 pub mod prelude;
@@ -27,6 +27,17 @@ impl bobbin_sys::board::Board for DiscoveryStm32f3 {
     fn id(&self) -> &'static str { "discovery-stm32f3" }    
 }
 
-cortex_m_rt::default_handler!(bobbin_sys::irq_dispatch::IrqDispatcher::<Mcu>::handle_exception);
-cortex_m_rt::exception!(SYS_TICK, bobbin_sys::tick::Tick::tick);
-cortex_m_rt::exception!(PENDSV, bobbin_sys::pend::Pend::pend);
+#[exception]
+fn DefaultHandler(_irqn: i16) {
+    bobbin_sys::irq_dispatch::IrqDispatcher::<Mcu>::handle_exception();
+}
+
+#[exception]
+fn SysTick() {
+    bobbin_sys::tick::Tick::tick();
+}
+
+#[exception]
+fn PendSV() {
+    bobbin_sys::pend::Pend::pend();
+}

--- a/board/discovery-stm32f429i/src/lib.rs
+++ b/board/discovery-stm32f429i/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
-#![feature(use_extern_macros)]
 
 extern crate panic_abort;
 extern crate cortex_m_rt;
+use cortex_m_rt::exception;
 pub extern crate stm32f42x as mcu;
 
 pub mod prelude;
@@ -27,6 +27,17 @@ impl bobbin_sys::board::Board for DiscoveryStm32f429i {
     fn id(&self) -> &'static str { "discovery-stm32f429i" }
 }
 
-cortex_m_rt::default_handler!(bobbin_sys::irq_dispatch::IrqDispatcher::<Mcu>::handle_exception);
-cortex_m_rt::exception!(SYS_TICK, bobbin_sys::tick::Tick::tick);
-cortex_m_rt::exception!(PENDSV, bobbin_sys::pend::Pend::pend);
+#[exception]
+fn DefaultHandler(_irqn: i16) {
+    bobbin_sys::irq_dispatch::IrqDispatcher::<Mcu>::handle_exception();
+}
+
+#[exception]
+fn SysTick() {
+    bobbin_sys::tick::Tick::tick();
+}
+
+#[exception]
+fn PendSV() {
+    bobbin_sys::pend::Pend::pend();
+}

--- a/board/feather-m0/src/lib.rs
+++ b/board/feather-m0/src/lib.rs
@@ -1,10 +1,10 @@
 #![no_std]
-#![feature(use_extern_macros)]
 
 extern crate panic_abort;
 extern crate cortex_m_rt;
-pub extern crate samd21 as mcu;
+use cortex_m_rt::exception;
 
+pub extern crate samd21 as mcu;
 
 pub mod prelude;
 pub mod led;
@@ -28,6 +28,18 @@ impl bobbin_sys::board::Board for FeatherM0 {
     fn id(&self) -> &'static str { "feather-m0" }    
 }
 
-cortex_m_rt::default_handler!(bobbin_sys::irq_dispatch::IrqDispatcher::<Mcu>::handle_exception);
-cortex_m_rt::exception!(SYS_TICK, bobbin_sys::tick::Tick::tick);
-cortex_m_rt::exception!(PENDSV, bobbin_sys::pend::Pend::pend);
+
+#[exception]
+fn DefaultHandler(_irqn: i16) {
+    bobbin_sys::irq_dispatch::IrqDispatcher::<Mcu>::handle_exception();
+}
+
+#[exception]
+fn SysTick() {
+    bobbin_sys::tick::Tick::tick();
+}
+
+#[exception]
+fn PendSV() {
+    bobbin_sys::pend::Pend::pend();
+}

--- a/board/frdm-k64f/src/lib.rs
+++ b/board/frdm-k64f/src/lib.rs
@@ -3,6 +3,8 @@
 
 extern crate panic_abort;
 extern crate cortex_m_rt;
+use cortex_m_rt::exception;
+
 pub extern crate k64 as mcu;
 
 pub mod prelude;
@@ -27,6 +29,17 @@ impl bobbin_sys::board::Board for FrdmK64f {
     fn id(&self) -> &'static str { "frdm-k64f" }    
 }
 
-cortex_m_rt::default_handler!(bobbin_sys::irq_dispatch::IrqDispatcher::<Mcu>::handle_exception);
-cortex_m_rt::exception!(SYS_TICK, bobbin_sys::tick::Tick::tick);
-cortex_m_rt::exception!(PENDSV, bobbin_sys::pend::Pend::pend);
+#[exception]
+fn DefaultHandler(_irqn: i16) {
+    bobbin_sys::irq_dispatch::IrqDispatcher::<Mcu>::handle_exception();
+}
+
+#[exception]
+fn SysTick() {
+    bobbin_sys::tick::Tick::tick();
+}
+
+#[exception]
+fn PendSV() {
+    bobbin_sys::pend::Pend::pend();
+}

--- a/board/nucleo-f429zi/src/lib.rs
+++ b/board/nucleo-f429zi/src/lib.rs
@@ -1,8 +1,9 @@
 #![no_std]
-#![feature(use_extern_macros)]
 
 extern crate panic_abort;
 extern crate cortex_m_rt;
+use cortex_m_rt::exception;
+
 pub extern crate stm32f42x as mcu;
 
 pub mod prelude;
@@ -27,6 +28,17 @@ impl bobbin_sys::board::Board for NucleoF429zi {
     fn id(&self) -> &'static str { "nucleo-f429zi" }    
 }
 
-cortex_m_rt::default_handler!(bobbin_sys::irq_dispatch::IrqDispatcher::<Mcu>::handle_exception);
-cortex_m_rt::exception!(SYS_TICK, bobbin_sys::tick::Tick::tick);
-cortex_m_rt::exception!(PENDSV, bobbin_sys::pend::Pend::pend);
+#[exception]
+fn DefaultHandler(_irqn: i16) {
+    bobbin_sys::irq_dispatch::IrqDispatcher::<Mcu>::handle_exception();
+}
+
+#[exception]
+fn SysTick() {
+    bobbin_sys::tick::Tick::tick();
+}
+
+#[exception]
+fn PendSV() {
+    bobbin_sys::pend::Pend::pend();
+}

--- a/board/nucleo-f746zg/src/lib.rs
+++ b/board/nucleo-f746zg/src/lib.rs
@@ -1,8 +1,9 @@
 #![no_std]
-#![feature(use_extern_macros)]
 
 extern crate panic_abort;
 extern crate cortex_m_rt;
+use cortex_m_rt::exception;
+
 pub extern crate stm32f74x as mcu;
 
 pub mod prelude;
@@ -27,6 +28,17 @@ impl bobbin_sys::board::Board for NucleoF746zg {
     fn id(&self) -> &'static str { "nucleo-f746zg" }    
 }
 
-cortex_m_rt::default_handler!(bobbin_sys::irq_dispatch::IrqDispatcher::<Mcu>::handle_exception);
-cortex_m_rt::exception!(SYS_TICK, bobbin_sys::tick::Tick::tick);
-cortex_m_rt::exception!(PENDSV, bobbin_sys::pend::Pend::pend);
+#[exception]
+fn DefaultHandler(_irqn: i16) {
+    bobbin_sys::irq_dispatch::IrqDispatcher::<Mcu>::handle_exception();
+}
+
+#[exception]
+fn SysTick() {
+    bobbin_sys::tick::Tick::tick();
+}
+
+#[exception]
+fn PendSV() {
+    bobbin_sys::pend::Pend::pend();
+}

--- a/board/nucleo-l432kc/src/lib.rs
+++ b/board/nucleo-l432kc/src/lib.rs
@@ -1,8 +1,9 @@
 #![no_std]
-#![feature(use_extern_macros)]
 
 extern crate panic_abort;
 extern crate cortex_m_rt;
+use cortex_m_rt::exception;
+
 pub extern crate stm32l432x as mcu;
 
 pub mod prelude;
@@ -27,6 +28,17 @@ impl bobbin_sys::board::Board for NucleoL432kc {
     fn id(&self) -> &'static str { "nucleo-l432kc" }    
 }
 
-cortex_m_rt::default_handler!(bobbin_sys::irq_dispatch::IrqDispatcher::<Mcu>::handle_exception);
-cortex_m_rt::exception!(SYS_TICK, bobbin_sys::tick::Tick::tick);
-cortex_m_rt::exception!(PENDSV, bobbin_sys::pend::Pend::pend);
+#[exception]
+fn DefaultHandler(_irqn: i16) {
+    bobbin_sys::irq_dispatch::IrqDispatcher::<Mcu>::handle_exception();
+}
+
+#[exception]
+fn SysTick() {
+    bobbin_sys::tick::Tick::tick();
+}
+
+#[exception]
+fn PendSV() {
+    bobbin_sys::pend::Pend::pend();
+}


### PR DESCRIPTION
Use newer `cortex-m-rt`'s [`#[exception]`](https://docs.rs/cortex-m-rt-macros/0.1.5/cortex_m_rt_macros/attr.exception.html) attribute instead of macros in the board support crates.